### PR TITLE
Improve recording outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,9 +16,4 @@ __pycache__/
 /venv/
 /Colony.prof
 *.prof
-/recording/trial1recording
-/recording/trial2recording
-/recording/trial3recording
-/recording/trial1results
-/recording/trial2results
-/recording/trial3results
+recording/results/*.json

--- a/Constants.py
+++ b/Constants.py
@@ -43,6 +43,8 @@ SECONDS_BETWEEN_SENDING_REQUESTS = 5  # Number of seconds between sending inform
 USE_REST_API = False  # Whether the interface sends information about the hub to the rest API
 # Having this set to False makes the interface a little faster because it doesn't have to record all the time.
 SHOULD_RECORD = True  # Whether the agents' positions, states, phases, and assigned sites will be recorded to be played again later.
+# Having this set to False makes the interface a little faster because it doesn' have to record all user commands
+SHOULD_RECORD_COMMANDS_ONLY = True
 # Having this set to False makes the interface a little faster because it doesn't have to draw all the time.
 SHOULD_DRAW = True  # Whether the interface is drawn on the screen
 # Having this false makes the interface faster because the paths do not have to be drawn on the screen so much.

--- a/recording/Recorder.py
+++ b/recording/Recorder.py
@@ -1,6 +1,8 @@
 import json
 import numbers
 
+from datetime import datetime
+
 from model.phases import Phase
 from model.states import State
 
@@ -40,6 +42,9 @@ class Recorder:
         self.currentMarkerIndex = -1
 
         self.dataIndex = -1
+
+        self.timestampString = datetime.now().strftime('%b-%d-%Y-%H:%M:%S')
+        self.outputFileBase = f'recording/results/{self.timestampString}'
 
     def recordAgentInfo(self, agent):
         self.recordAgentPosition(agent.getPosition())
@@ -135,8 +140,11 @@ class Recorder:
         self.siteMarkerNums = []
 
     def write(self):
-        with open('recording/recording.json', 'w') as file:
+        with open(f'{self.outputFileBase}_RECORDING.json', 'w') as file:
             json.dump(self.data, file)
+        with open(f'{self.outputFileBase}_COMMANDS.json', 'w') as file:
+            json.dump(self.executedCommands, file, indent=2, sort_keys=True)
+
         self.agentPositions.clear()
         self.agentAngles.clear()
         self.agentStates.clear()
@@ -151,16 +159,15 @@ class Recorder:
         self.siteMarkerNums.clear()
 
     def read(self):
-        with open('recording/recording.json', 'r') as file:
+        with open(self.outputFileBase, 'r') as file:
             self.data = json.load(file)
             self.time = self.data[0]['time']
 
-    @staticmethod
-    def writeResults(positions, qualities, simulationTime):
+    def writeResults(self, positions, qualities, simulationTime):
         results = {'positions': positions,
                    'qualities': qualities,
                    'simulationTime': simulationTime}
-        with open('recording/results.json', 'w') as file:
+        with open(f'{self.outputFileBase}_RESULTS.json', 'w') as file:
             json.dump(results, file)
 
     @staticmethod


### PR DESCRIPTION
Change recorder to output to timestamp-named files
in recording/results/ that are separated into
'ALL' (full recordings), 'COMMANDS', and 'RESULTS'.
Add recording/results/ to .gitignore.