### PR TITLE
Improve avoid and find new home faster

### DIFF
--- a/Constants.py
+++ b/Constants.py
@@ -29,6 +29,7 @@ SETTING_NAMES = ["CONVERGENCE_FRACTION", "SIM_DURATION", "FONT_SIZE", "LARGE_FON
 
 FONT_SIZE = 13  # The font size of most words in the simulation
 LARGE_FONT_SIZE = 40  # The font size for titles and such
+INITIAL_ZOOM = -6  # How far in or out the zoom is at the beginning
 
 NUM_HUBS = 1  # The number of starting homes or the number of colonies
 HUB_LOCATIONS = []  # A list of positions of where the original homes are located
@@ -178,7 +179,7 @@ PRED_POSITIONS = []  # Where the predators will start. No position = random
 AT_NEST_THRESHOLD = 6  # Influences the likelihood that an agent will go back to their assigned site from searching.
 
 # Lower threshold makes agents more likely to start searching from AT_NEST(not hub)
-SEARCH_THRESHOLD = 3  # Should go from AT_NEST to SEARCH
+SEARCH_THRESHOLD = 4  # Should go from AT_NEST to SEARCH
 # With 100 agents, 8 ==> about 1 agent every second; if transitions from search are disabled,
 # it takes about 45 seconds for half of the agents to go from AT_NEST to SEARCH
 SEARCH_FROM_HUB_THRESHOLD = 8  # Should go from AT_NEST(hub) to SEARCH
@@ -198,7 +199,7 @@ LEAD_THRESHOLD = 4  # Influences the likelihood that an agent will start recruit
 # The lower this value is, the lower the quality of nests that agents accept can be initially; however, it doesn't make much of a difference in the long run, because agents move from lower-ranked sites to higher-ranked sites either way.
 MIN_ACCEPT_VALUE = 255 / 2  # The minimum quality of a nest required for agents to accept it
 # The lower this size is, the earlier agents switch over to the committed phase, making other agents come to their site easier.
-QUORUM_DIVIDEND = 6  # numAgents/QUORUM_DIVIDEND agents need to be at a site before agents will commit to it
+QUORUM_DIVIDEND = 7  # numAgents/QUORUM_DIVIDEND agents need to be at a site before agents will commit to it
 
 KILL_THRESHOLD = 2  # # Influences the likelihood that a predator will kill an agent
 

--- a/display/Display.py
+++ b/display/Display.py
@@ -3,7 +3,7 @@ import numpy as np
 import pygame
 
 from Constants import SHOULD_DRAW, DRAW_FAR_AGENTS, WORDS_COLOR, SHOULD_DRAW_PATHS, LARGE_FONT_SIZE, \
-    SITE_RADIUS, FONT_SIZE, MAX_SEARCH_DIST, COMMIT_COLOR, BORDER_COLOR
+    SITE_RADIUS, FONT_SIZE, MAX_SEARCH_DIST, COMMIT_COLOR, BORDER_COLOR, INITIAL_ZOOM
 
 screen = None
 shouldDraw = SHOULD_DRAW
@@ -36,8 +36,8 @@ def createScreen():
         screen = pygame.display.set_mode((0, 0), pygame.RESIZABLE)
         origWidth = screen.get_width()
         origHeight = screen.get_height()
-        newWidth = origWidth
-        newHeight = origHeight
+        initWorldSize()
+        resetScreen()
     return screen
 
 
@@ -48,6 +48,10 @@ def resetScreen():
     newHeight = origHeight
     displacementX = 0
     displacementY = 0
+    while zoom < INITIAL_ZOOM:
+        zoomIn()
+    while zoom > INITIAL_ZOOM:
+        zoomOut()
 
 
 def writeCenter(surface, words, fontSize=LARGE_FONT_SIZE, color=WORDS_COLOR):
@@ -445,8 +449,8 @@ def initWorldSize():
     w, h = origWidth, origHeight
     m = MAX_SEARCH_DIST * 2 + h
     while h < m:
-        w += origWidth
-        h += origHeight
+        w += (origWidth / 16)
+        h += (origHeight / 16)
     worldSize = w, h
     worldLeft = (origWidth - w) / 2
     worldTop = (origHeight - h) / 2

--- a/interface/LiveSimulation.py
+++ b/interface/LiveSimulation.py
@@ -46,10 +46,8 @@ class LiveSimulation(Simulation, ABC):
         self.world = World(numHubs, numSites, hubLocations, hubRadii, hubAgentCounts, sitePositions,
                            siteQualities, siteRadii, siteRadius, numPredators, predPositions)
         self.initializeAgentList()
-        if Display.shouldDraw:
-            Display.initWorldSize()
-            if SHOULD_DRAW_FOG:
-                WorldDisplay.initFog(self.world.hubs)
+        if Display.shouldDraw and SHOULD_DRAW_FOG:
+            WorldDisplay.initFog(self.world.hubs)
 
         return self.world
 

--- a/interface/LiveSimulation.py
+++ b/interface/LiveSimulation.py
@@ -96,7 +96,7 @@ class LiveSimulation(Simulation, ABC):
                 agent.clearFog()
 
             agentNeighbors = self.getNeighbors(agent.getRect(), agentRectList)
-            agent.changeState(agentNeighbors)
+            agent.doStateActions(agentNeighbors)
             del agentNeighbors[:]
 
         if self.shouldRecord and self.recordAll:

--- a/interface/RecordingPlayer.py
+++ b/interface/RecordingPlayer.py
@@ -33,7 +33,6 @@ class RecordingPlayer(Simulation):
         self.addAddedAgents(self.world, addAfter)
         self.initializeAgentList()
         self.timer.simulationDuration = self.recorder.getNextTime()
-        Display.initWorldSize()
 
         return self.world
 

--- a/model/Agent.py
+++ b/model/Agent.py
@@ -71,10 +71,10 @@ class Agent:
     def setState(self, state):
         self.state = state
 
-    def changeState(self, neighborList):
+    def doStateActions(self, neighborList):
         if self.state.executeCommands():
             return
-        self.state.changeState(neighborList)
+        self.state.doStateActions(neighborList)
 
     def getStateNumber(self):
         return self.state.stateNumber

--- a/model/Agent.py
+++ b/model/Agent.py
@@ -310,9 +310,17 @@ class Agent:
                 agent.leadAgent = leadAgent
         return True
 
-    def quorumMet(self, numNeighbors):
+    def quorumMet(self, neighborList):
         """ Returns whether the agent met enough other agents at their assigned site to go into the commit phase """
-        return numNeighbors > self.world.initialHubAgentCounts[self.getHubIndex()] / QUORUM_DIVIDEND
+        return len(neighborList) > self.world.initialHubAgentCounts[self.getHubIndex()] / QUORUM_DIVIDEND or \
+            self.neighborIsCommitted(neighborList)
+
+    @staticmethod
+    def neighborIsCommitted(neighborList):
+        for neighbor in neighborList:
+            if neighbor.getStateNumber() == COMMIT:
+                return True
+        return False
 
     def tryConverging(self):
         if self.assignedSite.agentCount > self.world.initialHubAgentCounts[self.getHubIndex()] * CONVERGENCE_FRACTION:

--- a/model/World.py
+++ b/model/World.py
@@ -2,8 +2,6 @@
 import random
 import time
 
-import numpy as np
-
 import Constants
 from Constants import *
 from display import Display
@@ -51,7 +49,7 @@ class World:
         t1 = time.time()
         while len(self.hubLocations) < numHubs:
             nextPos = self.generateNextPos()
-            while self.tooCloseToOtherHubs(nextPos):
+            while self.tooCloseToEdge(nextPos) or self.tooCloseToOtherHubs(nextPos):
                 # Make sure the hubs are not too close together
                 nextPos = self.generateNextPos()
                 if time.time() - t1 > 0.7:
@@ -71,13 +69,15 @@ class World:
         y = int(np.sin(angle) * dist + neighborHubLocation[1])
         return [x, y]
 
+    @staticmethod
+    def tooCloseToEdge(nextPos):
+        return nextPos[0] < HUB_MIN_X or nextPos[0] > HUB_MAX_X or nextPos[1] < HUB_MIN_Y or nextPos[1] > HUB_MAX_Y
+
     def tooCloseToOtherHubs(self, nextPos):
-        """ If another hub is too close, return that hub's position. """
+        """ If another hub is too close, return True. """
         for i, pos in enumerate(self.hubLocations):
             if abs(pos[0] - nextPos[0]) < Constants.MAX_SEARCH_DIST + 2 * self.hubRadii[i] and \
-                    abs(pos[1] - nextPos[1]) < Constants.MAX_SEARCH_DIST + 2 * self.hubRadii[i] or \
-                    nextPos[0] < HUB_MIN_X or nextPos[0] > HUB_MAX_X or \
-                    nextPos[1] < HUB_MIN_Y or nextPos[1] > HUB_MAX_Y:
+                    abs(pos[1] - nextPos[1]) < Constants.MAX_SEARCH_DIST + 2 * self.hubRadii[i]:
                 return True
         return False
 
@@ -104,7 +104,7 @@ class World:
                 if len(self.siteList) < 2:
                     predators.append(Predator(self.siteList[len(self.hubs)], self))
                 else:
-                    predators.append(Predator(self.siteList[np.random.default_rng(12345).integers(len(self.hubs),len(self.siteList) - 1)],
+                    predators.append(Predator(self.siteList[np.random.default_rng(12345).integers(len(self.hubs), len(self.siteList) - 1)],
                                               self))
 
         return predators

--- a/model/states/AtNestState.py
+++ b/model/states/AtNestState.py
@@ -32,7 +32,7 @@ class AtNestState(State):
 
         if phaseNumber == ASSESS:
             if self.agent.isDoneAssessing():
-                self.acceptOrReject(len(neighborList))
+                self.acceptOrReject(neighborList)
                 return
 
         elif phaseNumber == CANVAS:
@@ -79,10 +79,10 @@ class AtNestState(State):
             self.agent.leadAgent.incrementFollowers()
             self.setState(FollowState(self.agent), self.agent.leadAgent.getPosition())
 
-    def acceptOrReject(self, numNeighbors):
+    def acceptOrReject(self, neighborList):
         # If they determine the site is good enough after they've been there long enough,
         if self.agent.estimatedQuality > MIN_ACCEPT_VALUE:
-            if self.agent.quorumMet(numNeighbors):
+            if self.agent.quorumMet(neighborList):
                 # enough agents are already at the site, so they skip canvasing and go straight to the committed phase
                 self.agent.setPhase(CommitPhase())
                 self.agent.transportOrReverseTandem(self)
@@ -95,6 +95,10 @@ class AtNestState(State):
             self.agent.setPhase(ExplorePhase())
             from model.states.SearchState import SearchState
             self.setState(SearchState(self.agent), None)
+
+    def moveAway(self, pos):
+        self.agent.setAngle(np.arctan2(self.agent.getAssignedSitePosition()[1] - self.agent.pos[1],
+                                       self.agent.getAssignedSitePosition()[0] - self.agent.pos[0]))
 
     def getCarried(self, transporter):
         if transporter.numFollowers < MAX_FOLLOWERS:

--- a/model/states/DeadState.py
+++ b/model/states/DeadState.py
@@ -10,6 +10,9 @@ class DeadState(State):
         super().__init__(agent)
         self.stateNumber = DEAD
 
+    def doStateActions(self, neighborList) -> None:
+        pass
+
     def changeState(self, neighborList) -> None:
         pass
 

--- a/model/states/LeadForwardState.py
+++ b/model/states/LeadForwardState.py
@@ -10,8 +10,8 @@ class LeadForwardState(RecruitState):
         super().__init__(agent)
         self.stateNumber = LEAD_FORWARD
 
-    def arriveAtSite(self, numNeighbors):
-        if self.agent.quorumMet(numNeighbors):  # If enough agents are at that site
+    def arriveAtSite(self, neighborList):
+        if self.agent.quorumMet(neighborList):  # If enough agents are at that site
             self.agent.setPhase(CommitPhase())  # Commit to the site
             self.agent.transportOrReverseTandem(self)
         else:

--- a/model/states/RecruitState.py
+++ b/model/states/RecruitState.py
@@ -45,7 +45,7 @@ class RecruitState(State):
                 self.agent.comingWithFollowers = False
                 if self.agent.getPhaseNumber() == COMMIT and self.agent.tryConverging():
                     return
-                self.arriveAtSite(len(neighborList))
+                self.arriveAtSite(neighborList)
             return
 
         if len(self.agent.knownSites) > 1:

--- a/model/states/SearchState.py
+++ b/model/states/SearchState.py
@@ -58,8 +58,8 @@ class SearchState(State):
                 return
 
     def moveAway(self, pos):
-        self.agent.setAngle(self.agent.getAngle() + np.pi)
-        self.goBackTowardSite(self.agent.getHub())
+        self.agent.setAngle(np.arctan2(self.agent.getAssignedSitePosition()[1] - self.agent.pos[1],
+                                       self.agent.getAssignedSitePosition()[0] - self.agent.pos[0]))
 
     def getCarried(self, transporter):
         if transporter.numFollowers < MAX_FOLLOWERS:

--- a/model/states/SearchState.py
+++ b/model/states/SearchState.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 from Constants import *
 from model.phases.AssessPhase import AssessPhase
 from model.states.State import State
@@ -33,11 +31,8 @@ class SearchState(State):
         self.setState(self, self.agent.target)
         self.agent.marker = None
 
-        avoidPlace = self.agent.getNearbyPlaceToAvoid()
-        if avoidPlace is not None:  # If the agent is too close to a place they are supposed to avoid
-            self.moveAway(avoidPlace)  # Turn away from it.
         # If agent finds a site within range then assess it
-        elif self.agent.siteInRangeIndex != -1:
+        if self.agent.siteInRangeIndex != -1:
             self.agent.addToKnownSites(self.agent.world.siteList[self.agent.siteInRangeIndex])
             # If the site is better than the one they were assessing, they assess it instead.
             if self.agent.estimateQuality(self.agent.world.siteList[self.agent.siteInRangeIndex]) > self.agent.estimatedQuality\
@@ -62,6 +57,10 @@ class SearchState(State):
                 self.getCarried(neighborList[i])
                 return
 
+    def moveAway(self, pos):
+        self.agent.setAngle(self.agent.getAngle() + np.pi)
+        self.goBackTowardSite(self.agent.getHub())
+
     def getCarried(self, transporter):
         if transporter.numFollowers < MAX_FOLLOWERS:
             self.agent.leadAgent = transporter
@@ -80,18 +79,6 @@ class SearchState(State):
             y = self.agent.getPosition()[1] - 1
         self.agent.setPosition(x, y)
         self.agent.setAngle(self.agent.angle - (1.1 * np.pi))
-
-    def moveAway(self, pos):
-        if pos[0] < self.agent.getPosition()[0]:
-            x = self.agent.getPosition()[0] + 1
-        else:
-            x = self.agent.getPosition()[0] - 1
-        if pos[1] < self.agent.getPosition()[1]:
-            y = self.agent.getPosition()[1] + 1
-        else:
-            y = self.agent.getPosition()[1] - 1
-        self.agent.setPosition(x, y)
-        self.agent.setAngle(self.agent.angle - np.random.uniform(np.pi / 2, np.pi))
 
     def toString(self):
         return "SEARCH"


### PR DESCRIPTION
This pull improves the avoid feature by having ants avoid the places they need to avoid no matter what state they are in. Before, they were only avoiding when they were in the search state. The search state's avoid feature has also become more smooth because before the ants looked like they were glitching for a few seconds when they first started to avoid an area, but now they smoothly just leave the area. They can find new homes faster now because the threshold for them to commit was lowered, the threshold for them to leave a site and search again was lowered slightly, and the default zoom was zoomed out a little. For some reason, the simulation runs faster when it is zoomed out more. This is something I want to fix, but I don't want to fix it by slowing down the zoomed out mode, which would be easy to implement. I want to do it by speeding up the zoomed in mode, but this is difficult for me.